### PR TITLE
feat(api): get a list of job postings

### DIFF
--- a/controllers/recruitmentController.js
+++ b/controllers/recruitmentController.js
@@ -38,8 +38,18 @@ const deleteRecruitment = async (req, res) => {
   res.status(204).json({});
 };
 
+const getRecruitment = async (req, res) => {
+  let searchWord = req.query.search;
+  if (!searchWord) {
+    searchWord = ".";
+  }
+  const recruitmentList = await recruitmentService.getRecruitment(searchWord);
+  res.status(200).json({ recruitmentList });
+};
+
 module.exports = {
   registerRecruitment,
   updateRecruitment,
   deleteRecruitment,
+  getRecruitment,
 };

--- a/routes/recruitmentRouter.js
+++ b/routes/recruitmentRouter.js
@@ -10,6 +10,8 @@ router.patch("/:id", errorHandler(recruitmentController.updateRecruitment));
 
 router.delete("/:id", errorHandler(recruitmentController.deleteRecruitment));
 
+router.get("/", errorHandler(recruitmentController.getRecruitment));
+
 module.exports = {
   router,
 };


### PR DESCRIPTION
### 1. 채용공고 목록을 가져오는 기능 구현.

- get 요청시 모든 채용공고 리스트를 가져오는 기능을 구현하였습니다.
- orm으로 처리시 데이터 양식이 안 예쁜거 같아서 raw 쿼리로 구현하였습니다.

### 2. 채용공고 검색 기능 구현.

- 같은 url("/recruitment")에 쿼리 스트링만 붙이는 방식으로 구현하였습니다.(/recruitment?search=word)
-  if문을 사용해 한개의 쿼리문으로 전체리스트 가져오기, 검색 후 리스트 가져오기를 모두 가능하게 만들었습니다.
-  하나의 단어로 모든 데이터를 조회하게 만들었습니다.(stack_name, company_name, position 등등)